### PR TITLE
Bug fix: await in non setup script fails build 

### DIFF
--- a/client/app/src/views/HighlightRecipe.vue
+++ b/client/app/src/views/HighlightRecipe.vue
@@ -56,7 +56,11 @@ import { useRecipestore } from "../stores/RecipeStore.js";
 
 const store = useRecipestore();
 
-const res = await store.updateAllRecipes();
+store.updateAllRecipes().then(()=>{
+
+}).catch((ex)=>{
+  console.log("exception");
+});
 
 console.log(store.items);
 


### PR DESCRIPTION
# Purpose of PR
to replace the await to then condition as some browsers do not support it until it's on the setup 

# Details of changes
changes the await to then so that the async promise can be fine 

# Testing
ran npm build 
testing the site locally 
