### PR TITLE
Bug fix : Browse all categories cashing 

### DIFF
--- a/client/app/src/stores/ingridentsStore.js
+++ b/client/app/src/stores/ingridentsStore.js
@@ -13,7 +13,14 @@ export const useIngridentsStore = defineStore({
   }),
   getters: {
     getItems: () => {
-      return this.items;
+      if(this.item.length > 0)
+        return this.items;
+      
+      this.updateAllIngredients().then(()=>{
+        return this.items;
+      }).catch((ex)=>{
+        console.log(ex);
+      })
     }
   },
   actions: {
@@ -44,6 +51,9 @@ export const useIngridentsStore = defineStore({
     },
     getCategories() {
       let cat = [];
+      if(this.categories.length > 0)
+        return this.categories; 
+
       for (let i = 0; i < this.items.length; i++) {
         cat.push(this.items[i].category)
       }


### PR DESCRIPTION
# Purpose of PR
to cash the categories so getCatagores does not iterate too much 

# Details of changes
chasing this. categories for the ingredients store.

# Testing
npm run and tested it on dev throttling on mobile
npm run build to make sure build is successful 
